### PR TITLE
Add Dockerfile for local development

### DIFF
--- a/configs/default-config.yaml
+++ b/configs/default-config.yaml
@@ -1,0 +1,14 @@
+bm_0:
+  access_size: 512
+  total_memory_range: 10240
+  number_operations: 3000
+  exec_mode: sequential
+  number_threads: 2
+
+bm_1:
+  access_size: 512
+  number_operations: 3000
+  exec_mode: random
+  pause_frequency: 0
+
+bm_seq_read:

--- a/configs/dev-config.yaml
+++ b/configs/dev-config.yaml
@@ -1,21 +1,6 @@
 bm_0:
-  access_size: 512
-  total_memory_range: 10240
-  number_operations: 3000
+  access_size: 256
+  total_memory_range: 100
+  number_operations: 100
   exec_mode: sequential
-  number_threads: 2
-
-bm_1:
-  access_size: 512
-  total_memory_range: 10240
-  number_operations: 3000
-  exec_mode: sequential_desc
-  number_threads: 2
-
-bm_2:
-  access_size: 512
-  number_operations: 3000
-  exec_mode: random
-  pause_frequency: 0
-
-bm_seq_read:
+  number_threads: 1

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -2,12 +2,7 @@
 # Taken and modified from: https://blog.jetbrains.com/clion/2020/01/using-docker-with-clion
 #
 # Build and run:
-#   docker build -t clion/remote-pmem scripts
-#   docker run -d --cap-add sys_ptrace -p127.0.0.1:2222:22 --name clion_remote_pmem clion/remote-pmem
-#   ssh-keygen -f "$HOME/.ssh/known_hosts" -R "[localhost]:2222"
-#
-# stop:
-#   docker stop clion_remote_pmem
+#   Check out the run_docker.sh file or the link above for details.
 #
 # ssh credentials (test user):
 #   user@password
@@ -26,10 +21,10 @@ RUN ( \
     echo 'PermitRootLogin yes'; \
     echo 'PasswordAuthentication yes'; \
     echo 'Subsystem sftp /usr/lib/openssh/sftp-server'; \
-  ) > /etc/ssh/sshd_config_test_clion \
+  ) > /etc/ssh/sshd_config_remote_pmem \
   && mkdir /run/sshd
 
 RUN useradd -m user \
   && yes password | passwd user
 
-CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config_test_clion"]
+CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config_remote_pmem"]

--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Get directory of this file so that we always use the Dockerfile in the correct dir
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Create the docker image with the name remote-pmem
+docker build -t remote-pmem ${DIR}
+
+# Start the docker with ...
+#   - remote debugging options
+#   - ssh port forwarding to host 2222
+#   - a mounted tempfs at /mnt/pmem to simulated PMem
+#   - name = remote_pmem
+docker run -d --cap-add sys_ptrace -p127.0.0.1:2222:22 \
+              --tmpfs /mnt/pmem:rw,size=512m \
+              --name remote_pmem remote-pmem
+
+# Remove any known_host entries for localhost:2222. If this is the first run,
+# it will probably look like it "failed" but that is to be expected,
+# as there are no entries yet.
+ssh-keygen -f "$HOME/.ssh/known_hosts" -R "[localhost]:2222"

--- a/src/benchmark_factory.cpp
+++ b/src/benchmark_factory.cpp
@@ -8,13 +8,15 @@
 
 namespace perma {
 
-std::vector<std::unique_ptr<Benchmark>> BenchmarkFactory::create_benchmarks(const std::string& file_name) {
+std::vector<std::unique_ptr<Benchmark>> BenchmarkFactory::create_benchmarks(const std::filesystem::path& pmem_directory,
+                                                                            const std::filesystem::path& config_file) {
   std::vector<std::unique_ptr<Benchmark>> benchmarks;
   try {
-    YAML::Node config = YAML::LoadFile(file_name);
+    YAML::Node config = YAML::LoadFile(config_file);
     for (YAML::iterator it = config.begin(); it != config.end(); ++it) {
       BenchmarkConfig bm_config = BenchmarkConfig::decode(it->second);
-      benchmarks.push_back(std::make_unique<Benchmark>(it->first.as<std::string>(), bm_config));
+      bm_config.pmem_directory = pmem_directory;
+      benchmarks.push_back(std::make_unique<Benchmark>(it->first.as<std::string>(), std::move(bm_config)));
     }
   } catch (const YAML::ParserException& e1) {
     throw std::runtime_error{"Exception during config parsing: " + e1.msg};

--- a/src/benchmark_factory.hpp
+++ b/src/benchmark_factory.hpp
@@ -6,7 +6,8 @@ namespace perma {
 
 class BenchmarkFactory {
  public:
-  static std::vector<std::unique_ptr<Benchmark>> create_benchmarks(const std::string& file_name);
+  static std::vector<std::unique_ptr<Benchmark>> create_benchmarks(const std::filesystem::path& pmem_directory,
+                                                                   const std::filesystem::path& config_file);
 };
 
 }  // namespace perma

--- a/src/benchmark_suite.cpp
+++ b/src/benchmark_suite.cpp
@@ -7,8 +7,9 @@
 
 namespace perma {
 
-void BenchmarkSuite::run_benchmarks(const std::string& file_name) {
-  benchmarks_ = BenchmarkFactory::create_benchmarks(file_name);
+void BenchmarkSuite::run_benchmarks(const std::filesystem::path& pmem_directory,
+                                    const std::filesystem::path& config_file) {
+  benchmarks_ = BenchmarkFactory::create_benchmarks(pmem_directory, config_file);
   for (std::unique_ptr<Benchmark>& benchmark : benchmarks_) {
     benchmark->generate_data();
     benchmark->set_up();

--- a/src/benchmark_suite.hpp
+++ b/src/benchmark_suite.hpp
@@ -6,7 +6,7 @@ namespace perma {
 
 class BenchmarkSuite {
  public:
-  void run_benchmarks(const std::string& file_name);
+  void run_benchmarks(const std::filesystem::path& pmem_directory, const std::filesystem::path& config_file);
 
  private:
   std::vector<std::unique_ptr<Benchmark>> benchmarks_;

--- a/src/perma.cpp
+++ b/src/perma.cpp
@@ -1,16 +1,35 @@
+#include <iostream>
+
 #include "benchmark_suite.hpp"
 
 using namespace perma;
 
-constexpr auto DEFAULT_CONFIG_PATH = "configs/dev-config.yaml";
+constexpr auto DEFAULT_CONFIG_PATH = "configs/default-config.yaml";
 
 int main(int argc, char** argv) {
   std::filesystem::path config_file = std::filesystem::current_path() / ".." / DEFAULT_CONFIG_PATH;
-  if (argc == 2) {
-    config_file = argv[1];
+  if (argc < 2) {
+    std::cerr << "Usage: ./perma-bench /path/to/pmem/dir [/path/to/config]" << std::endl;
+    throw std::invalid_argument{"Need to specify pmem directory."};
+  }
+
+  const std::filesystem::path pmem_directory = argv[1];
+  const bool pmem_dir_exists = std::filesystem::exists(pmem_directory);
+  if (pmem_dir_exists && !std::filesystem::is_directory(pmem_directory)) {
+    throw std::invalid_argument{"Need to specify pmem directory but got: " + pmem_directory.string()};
+  }
+
+  if (argc > 2) {
+    // Use config file specified by user.
+    config_file = argv[2];
   }
   BenchmarkSuite bm_suite{};
-  bm_suite.run_benchmarks(config_file);
+  bm_suite.run_benchmarks(pmem_directory, config_file);
+
+  if (!pmem_dir_exists) {
+    // We created the directory, so we should remove it again.
+    std::filesystem::remove_all(pmem_directory);
+  }
 
   return 0;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,7 +2,9 @@
 
 #include <libpmem.h>
 
+#include <algorithm>
 #include <iostream>
+#include <random>
 
 namespace perma {
 
@@ -37,6 +39,21 @@ char* create_pmem_file(const std::filesystem::path& file, size_t length) {
   }
 
   return static_cast<char*>(pmem_addr);
+}
+
+std::filesystem::path generate_random_file_name(const std::filesystem::path& base_dir) {
+  if (!std::filesystem::exists(base_dir)) {
+    if (!std::filesystem::create_directories(base_dir)) {
+      throw std::runtime_error{"Could not create dir: " + base_dir.string()};
+    }
+  }
+  std::string str("abcdefghijklmnopqrstuvwxyz");
+  std::random_device rd;
+  std::mt19937 generator(rd());
+  std::shuffle(str.begin(), str.end(), generator);
+  const std::string file_name = str + ".file";
+  const std::filesystem::path file{file_name};
+  return base_dir / file;
 }
 
 uint64_t duration_to_nanoseconds(const std::chrono::high_resolution_clock::duration duration) {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -7,6 +7,8 @@ namespace perma {
 char* map_pmem_file(const std::filesystem::path& file, size_t* mapped_length);
 char* create_pmem_file(const std::filesystem::path& file, size_t length);
 
+std::filesystem::path generate_random_file_name(const std::filesystem::path& base_dir);
+
 uint64_t duration_to_nanoseconds(std::chrono::high_resolution_clock::duration duration);
 
 }  // namespace perma


### PR DESCRIPTION
This can now be used as a "remote" host but without needing server access. This allows us to develop locally and only test on the servers, when we need to. Obviously, Docker will not contain persistent memory, but PMDK can abstract from that. Also, this gives us quite a bit of testing flexibility, which we will need to support different system.

Follow the instructions in the link in the head comment of the Dockerfile to set up the system with docker as the remote host.