### PR TITLE
Refactor flush instruction abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,28 +57,6 @@ else ()
     message(STATUS "System does not support CLWB.")
 endif ()
 
-##################### CLFLUSHOPT ####################
-
-set(clflushopt_prog "
-#include <cpuid.h>
-int main() {
-  unsigned cpuinfo[4] = {0};
-  __cpuid_count(0x0, 0x0, cpuinfo[0], cpuinfo[1], cpuinfo[2], cpuinfo[3]);
-  if (cpuinfo[0] < 0x7) {
-    return 1;
-  }
-  __cpuid_count(0x7, 0x0, cpuinfo[0], cpuinfo[1], cpuinfo[2], cpuinfo[3]);
-  return (cpuinfo[1] & (1 << 23)) == 0; }")
-set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -mclflushopt")
-check_c_source_runs("${clflushopt_prog}" HAS_CLFLUSHOPT)
-if (${HAS_CLFLUSHOPT})
-    # Set HAS_CLFLUSHOPT so we can use it to enable all explicit CLFLUSHOPT instructions.
-    add_definitions("-DHAS_CLFLUSHOPT")
-    message(STATUS "System supports CLFLUSHOPT.")
-else ()
-    message(STATUS "System does not support CLFLUSHOPT.")
-endif ()
-
 ##################### PMDK ####################
 option(BUILD_PMDK "Set true if PMDK should be downloaded and built from source.")
 option(PMDK_INCLUDE_PATH "Path to custom PMDK include files" "")

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -111,10 +111,9 @@ const std::unordered_map<std::string, internal::DataInstruction> ConfigEnums::st
     {"simd", internal::DataInstruction::SIMD}, {"mov", internal::DataInstruction::MOV}};
 
 const std::unordered_map<std::string, internal::PersistInstruction> ConfigEnums::str_to_persist_instruction{
-    {"ntstore", internal::PersistInstruction::NTSTORE},
-    {"clwb", internal::PersistInstruction::CLWB},
-    {"clflush", internal::PersistInstruction::CLFLUSH},
-    {"none", internal::PersistInstruction::NONE}};
+    {"nocache", internal::PersistInstruction::NoCache},
+    {"cache", internal::PersistInstruction::Cache},
+    {"none", internal::PersistInstruction::None}};
 
 const std::unordered_map<std::string, internal::RandomDistribution> ConfigEnums::str_to_random_distribution{
     {"uniform", internal::RandomDistribution::Uniform}, {"zipf", internal::RandomDistribution::Zipf}};

--- a/src/benchmark.hpp
+++ b/src/benchmark.hpp
@@ -60,7 +60,7 @@ struct BenchmarkConfig {
   double zipf_alpha = 0.99;
 
   internal::DataInstruction data_instruction{internal::DataInstruction::SIMD};
-  internal::PersistInstruction persist_instruction{internal::PersistInstruction::NTSTORE};
+  internal::PersistInstruction persist_instruction{internal::PersistInstruction::NoCache};
 
   double write_ratio = 0.0;
   double read_ratio = 1.0;

--- a/src/read_write_ops.hpp
+++ b/src/read_write_ops.hpp
@@ -39,19 +39,6 @@ static constexpr size_t CACHE_LINE_SIZE = 64;
 typedef void flush_fn(const void*, const size_t);
 
 /*
- * flush the CPU cache using clflushopt.
- */
-#ifdef HAS_CLFLUSHOPT
-inline void flush_clflushopt(const void* addr, const size_t len) {
-  uintptr_t uptr;
-
-  for (uptr = (uintptr_t)addr; uptr < (uintptr_t)addr + len; uptr += CACHE_LINE_SIZE) {
-    asm volatile(".byte 0x66; clflush %0" : "+m"(*(volatile char*)(uptr)));
-  }
-}
-#endif
-
-/*
  * flush the CPU cache using clwb.
  */
 #ifdef HAS_CLWB
@@ -119,12 +106,6 @@ inline void simd_write_nt(const std::vector<char*>& addresses, const size_t acce
 #ifdef HAS_CLWB
 inline void simd_write_clwb(const std::vector<char*>& addresses, const size_t access_size) {
   simd_write(addresses, access_size, flush_clwb, sfence_barrier);
-}
-#endif
-
-#ifdef HAS_CLFLUSHOPT
-inline void simd_write_clflush(const std::vector<char*>& addresses, const size_t access_size) {
-  simd_write(addresses, access_size, flush_clflushopt, sfence_barrier);
 }
 #endif
 
@@ -265,12 +246,6 @@ inline void mov_write(const std::vector<char*>& addresses, const size_t access_s
 #ifdef HAS_CLWB
 inline void mov_write_clwb(const std::vector<char*>& addresses, const size_t access_size) {
   mov_write(addresses, access_size, flush_clwb, sfence_barrier);
-}
-#endif
-
-#ifdef HAS_CLFLUSHOPT
-inline void mov_write_clflush(const std::vector<char*>& addresses, const size_t access_size) {
-  mov_write(addresses, access_size, flush_clflushopt, sfence_barrier);
 }
 #endif
 

--- a/test/read_write_test.cpp
+++ b/test/read_write_test.cpp
@@ -63,10 +63,6 @@ TEST_F(ReadWriteTest, SIMDNoneWrite) { run_write_test(rw_ops::simd_write_none); 
 TEST_F(ReadWriteTest, SIMDCacheLineWriteBackWrite) { run_write_test(rw_ops::simd_write_clwb); }
 #endif
 
-#ifdef HAS_CLFLUSHOPT
-TEST_F(ReadWriteTest, SIMDCacheLineFlushOptWrite) { run_write_test(rw_ops::simd_write_clflush); }
-#endif
-
 TEST_F(ReadWriteTest, SIMDNonTemporalWrite) { run_write_test(rw_ops::simd_write_nt); }
 #endif
 
@@ -74,10 +70,6 @@ TEST_F(ReadWriteTest, MOVNoneWrite) { run_write_test(rw_ops::mov_write_none); }
 
 #ifdef HAS_CLWB
 TEST_F(ReadWriteTest, MOVCacheLineWriteBackWrite) { run_write_test(rw_ops::mov_write_clwb); }
-#endif
-
-#ifdef HAS_CLFLUSHOPT
-TEST_F(ReadWriteTest, MOVCacheLineFlushOptWrite) { run_write_test(rw_ops::mov_write_clflush); }
 #endif
 
 TEST_F(ReadWriteTest, MOVNonTemporalWrite) { run_write_test(rw_ops::mov_write_nt); }


### PR DESCRIPTION
Only differentiate between cache, nocache, and none. Remove everything related to CLFLUSH(OPT). Solves #76.