### PR TITLE
Update Table Scan Workload

### DIFF
--- a/configs/workloads/table_scan.yaml
+++ b/configs/workloads/table_scan.yaml
@@ -1,20 +1,24 @@
 # Represents the database workload table scan (sequential read)
-table_scan_large:
+table_scan:
   matrix:
     number_threads: [ 1, 2, 4, 8, 16, 32, 36 ]
-    access_size: [ 64, 256, 4096, 16384, 1048576 ] # [64B, 256B, 4 KiB, 16 KiB, 1 MiB]
+    # [64 B, 256 B, 4 KiB, 16 KiB, 64 KiB]
+    access_size: [ 64, 256, 4096, 16384, 65536 ]
+
 
   args:
     exec_mode: sequential
-    total_memory_range: 10737418240 # 10 GiB
+    total_memory_range: 53687091200 # 50 GiB
     write_ratio: 0
 
-table_scan_small:
+table_scan_partitioned:
   matrix:
-    number_threads: [ 1, 2, 4, 8, 16, 32, 36 ]
-    access_size: [ 64, 256, 4096, 16384, 1048576 ] # [64B, 256B, 4 KiB, 16 KiB, 1 MiB]
+    number_partitions: [ 1, 2, 4, 8, 16, 32 ]
+    # [64 B, 256 B, 4 KiB, 16 KiB, 64 KiB]
+    access_size: [ 64, 256, 4096, 16384, 65536 ]
 
   args:
+      number_threads: 32
       exec_mode: sequential
-      total_memory_range: 1073741824 # 1 GiB
+      total_memory_range: 53687091200 # 50 GiB
       write_ratio: 0


### PR DESCRIPTION
We now work on larger tables (should give us more stable results) and with a partitioned table scan instead of a "tiny" one.