### PR TITLE
Run larger logging workload

### DIFF
--- a/workloads/logging.yaml
+++ b/workloads/logging.yaml
@@ -2,24 +2,22 @@
 logging:
   matrix:
     number_threads: [ 1, 2, 4, 8, 16, 32 ]
-    # ~[168 mil ops, 84 mil ops, 42 mil ops, 21 mil ops, 10 mil ops]
     access_size: [ 64, 128, 256, 512, 1024 ]
     persist_instruction: [ nocache, none ]
 
   args:
-    total_memory_range: 10G
+    total_memory_range: 30G
     exec_mode: sequential
     write_ratio: 1
 
 logging_partition:
   matrix:
     number_partitions: [ 1, 2, 4, 8 ]
-    # [168 mil ops, 84 mil ops, 42 mil ops, 21 mil ops, 10 mil ops]
     access_size: [ 64, 128, 256, 512, 1024 ]
     persist_instruction: [ nocache, none ]
 
   args:
-    total_memory_range: 10G
+    total_memory_range: 30G
     number_threads: 8
     exec_mode: sequential
     write_ratio: 1


### PR DESCRIPTION
I thought I had changed this already. But we should run logging with 30 GB and not 10. 
Don't merge before #139 to ensure that it was copied correctly.