### PR TITLE
Change page propagation workload

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -12,7 +12,7 @@
 namespace {
 
 #define CHECK_ARGUMENT(exp, txt) \
-  if (!exp) {                    \
+  if (!(exp)) {                  \
     spdlog::critical(txt);       \
     perma::crash_exit();         \
   }

--- a/workloads/page_propagation.yaml
+++ b/workloads/page_propagation.yaml
@@ -1,26 +1,14 @@
-# Represents the data base workload page propagation (large random writes)
-page_propagation_write:
+# Represents the data base workload page propagation
+#   (page-sized random writes/reads)
+page_propagation:
   matrix:
     number_threads: [ 1, 8, 16 ]
     access_size: [ 512, 4096, 16384 ]
-    random_distribution: [ uniform, zipf ]
+    write_ratio: [ 0, 0.2, 0.5, 0.8, 1 ]
 
   args:
     total_memory_range: 50G
     number_operations: 10000000 # 10 million
     persist_instruction: nocache
     exec_mode: random
-    write_ratio: 1
-
-page_propagation_mixed:
-  matrix:
-    number_threads: [ 1, 8, 16 ]
-    access_size: [ 512, 4096, 16384 ]
-    random_distribution: [ uniform, zipf ]
-
-  args:
-    total_memory_range: 50G
-    number_operations: 10000000 # 10 million
-    persist_instruction: nocache
-    exec_mode: random
-    write_ratio: 0.2
+    random_distribution: uniform


### PR DESCRIPTION
This PR merges the two page propagation workloads. The Zipfian access is not as realistic as we assumed. We now vary the write ratio, which gives us better insights.