### PR TITLE
Add iomanip header

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In case you do not want to or can't install the development version, you can als
 using the `numactl` command line tool and disabling NUMA-awareness in PerMA-Bench via the `--no-numa` flag.
 You should pin the application to the nodes that are close to your mounted persistent memory filesystem for the best performance e.g., like this:
 
-```shel script
+```shell script
 $ numactl -N 0,1 ./perma-bench --path /path/to/pmem/filesystem --no-numa
 ```
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <iomanip>
 #include <random>
 #include <thread>
 


### PR DESCRIPTION
`std::setw` and `std::put_time` are defined in `iomanip`. Works on some compilers without but not all. 