### PR TITLE
Add multi-threaded tests

### DIFF
--- a/test/benchmark_test.cpp
+++ b/test/benchmark_test.cpp
@@ -421,7 +421,6 @@ TEST_F(BenchmarkTest, RunSingeThreadMixed) {
   ASSERT_EQ(result.raw_measurements.size(), 0);
 }
 
-/* TODO: fix tests
 TEST_F(BenchmarkTest, RunMultiThreadRead) {
   const size_t ops_per_chunk = TEST_IO_OP_CHUNK_SIZE / 1024;
   const size_t num_chunks = 32;
@@ -583,7 +582,7 @@ TEST_F(BenchmarkTest, RunMultiThreadWriteRaw) {
 
   check_file_written(bm.get_pmem_files()[0], total_size);
 }
-*/
+
 
 TEST_F(BenchmarkTest, ResultsSingleThreadRead) {
   const size_t ops_per_chunk = TEST_IO_OP_CHUNK_SIZE / 256;


### PR DESCRIPTION
Closes #93, as this does not seem to be the case anymore and there is no segfault.